### PR TITLE
Add deprecation notice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 `Illusionist` will make you believe ES6 is already available in browsers
 
+## Deprecation notice
+
+:warning: This repository is now deprecated in favor of
+[`babel`](https://github.com/babel/babel) which supports ECMAScript transpilation
+and module exporting.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Since we’re now using [`babel`](https://github.com/babel/babel) and [`sprockets-es6`](https://github.com/josh/sprockets-es6), we can now mark this repo as deprecated (we’ll also add a _[deprecated]_ tag in the GitHub repo description).

This was a fun ride! Props to @charlesdemers for building this awesome package! :metal: 

![](http://i.imgur.com/R6At161.gif)
